### PR TITLE
Release `next`: 2024/03/01 (part 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "branches": [
       "main"
     ]
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
### Description

This is to address a bug in the release process of `semantic-release` assuming the NPM package is private and therefore requires payment.