### PR TITLE
fix: package repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/thuoe/util-directives.git"
+    "url": "https://github.com/thuoe/gql-util-directives.git"
   },
   "license": "ISC",
   "author": "Eddie Thuo",


### PR DESCRIPTION
### Description

This is a hotfix to make the release process pass.

`@semantic-release/github` used for automating GitHub releases fails during a package release since it relies on the repository URL from the `package.json`
